### PR TITLE
Omit fields extra typescript option

### DIFF
--- a/aeson-typescript.cabal
+++ b/aeson-typescript.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -72,6 +72,7 @@ test-suite aeson-typescript-tests
       NoOmitNothingFields
       ObjectWithSingleFieldNoTagSingleConstructors
       ObjectWithSingleFieldTagSingleConstructors
+      OmitFields
       OmitNothingFields
       OpenTypeFamilies
       TaggedObjectNoTagSingleConstructors

--- a/src/Data/Aeson/TypeScript/TH.hs
+++ b/src/Data/Aeson/TypeScript/TH.hs
@@ -133,6 +133,7 @@ module Data.Aeson.TypeScript.TH (
   -- * Advanced options
   , defaultExtraTypeScriptOptions
   , keyType
+  , omitFields
   , typeFamiliesToMapToTypeScript
   , ExtraTypeScriptOptions
 

--- a/src/Data/Aeson/TypeScript/Types.hs
+++ b/src/Data/Aeson/TypeScript/Types.hs
@@ -179,10 +179,11 @@ allStarConstructors'' = ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "
 data ExtraTypeScriptOptions = ExtraTypeScriptOptions {
   typeFamiliesToMapToTypeScript :: [Name]
   , keyType :: Maybe String
+  , omitFields :: [String]
   }
 
 defaultExtraTypeScriptOptions :: ExtraTypeScriptOptions
-defaultExtraTypeScriptOptions = ExtraTypeScriptOptions [] Nothing
+defaultExtraTypeScriptOptions = ExtraTypeScriptOptions [] Nothing []
 
 data ExtraDeclOrGenericInfo = ExtraDecl Exp
                             | ExtraGeneric GenericInfo

--- a/src/Data/Aeson/TypeScript/Util.hs
+++ b/src/Data/Aeson/TypeScript/Util.hs
@@ -150,8 +150,9 @@ mkInstance = InstanceD
 
 namesAndTypes :: ExtraTypeScriptOptions -> Options -> [(Name, (Suffix, Var))] -> ConstructorInfo -> [(String, Type)]
 namesAndTypes extraOptions options genericVariables ci = case constructorVariant ci of
-  RecordConstructor names -> let indiciesToDrop = foldr (\(i, recordFieldName) skipped -> if recordFieldName `elem` omitFields extraOptions then i:skipped else skipped) [] $ zip [(0 :: Int)..] $ fmap lastNameComponent' names
-                             in dropIndicies indiciesToDrop $ zip (fmap ((fieldLabelModifier options) . lastNameComponent') names) (constructorFields ci)
+  RecordConstructor names -> fmap (\(recordFieldName, t) -> (fieldLabelModifier options recordFieldName, t)) 
+                               $ filter (\(recordFieldName, _) -> recordFieldName `notElem` omitFields extraOptions) 
+                               $ zip (fmap lastNameComponent' names) (constructorFields ci)                         
   _ -> case sumEncoding options of
     TaggedObject _ contentsFieldName
       | isConstructorNullary ci -> []

--- a/test/OmitFields.hs
+++ b/test/OmitFields.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+
+module OmitFields (allTests) where
+
+import Data.Aeson as A
+import Data.Aeson.TypeScript.TH
+import Data.Aeson.TypeScript.Types
+import Data.Proxy
+import Data.String.Interpolate
+import Prelude hiding (Double)
+import Test.Hspec
+
+
+data TwoField = TwoField { doubleInt :: Int, doubleString :: String }
+$(deriveTypeScript' A.defaultOptions ''TwoField defaultExtraTypeScriptOptions {omitFields =["doubleInt"]})
+
+
+allTests :: SpecWith ()
+allTests = describe "OmitFields tests" $ do
+    it [i|Removes a field|] $ do
+        (getTypeScriptDeclarations (Proxy :: Proxy TwoField)) `shouldBe` [
+            TSTypeAlternatives {typeName = "TwoField", typeGenericVariables = [], alternativeTypes = ["ITwoField"]},
+            TSInterfaceDeclaration {interfaceName = "ITwoField", interfaceGenericVariables = [], interfaceMembers = [TSField {fieldOptional = False, fieldName = "doubleString", fieldType = "string"}]}
+            ]
+

--- a/test/OmitFields.hs
+++ b/test/OmitFields.hs
@@ -18,6 +18,7 @@ module OmitFields (allTests) where
 import Data.Aeson as A
 import Data.Aeson.TypeScript.TH
 import Data.Aeson.TypeScript.Types
+import Data.Char (toLower)
 import Data.Proxy
 import Data.String.Interpolate
 import Prelude hiding (Double)
@@ -27,12 +28,28 @@ import Test.Hspec
 data TwoField = TwoField { doubleInt :: Int, doubleString :: String }
 $(deriveTypeScript' A.defaultOptions ''TwoField defaultExtraTypeScriptOptions {omitFields =["doubleInt"]})
 
+data EmptyTypeScript = EmptyTypeScript { emptyInt :: Int, emptyString :: String }
+$(deriveTypeScript' A.defaultOptions ''EmptyTypeScript defaultExtraTypeScriptOptions {omitFields =["emptyInt", "emptyString"]})
+
+data IgnoreFieldLabelModifier = IgnoreFieldLabelModifier { prefixInt :: Int, prefixString :: String }
+$(deriveTypeScript' A.defaultOptions {A.fieldLabelModifier = map toLower . drop 6} ''IgnoreFieldLabelModifier defaultExtraTypeScriptOptions {omitFields =["int", "prefixString"]})
 
 allTests :: SpecWith ()
 allTests = describe "OmitFields tests" $ do
-    it [i|Removes a field|] $ do
+    it [i|removes a field|] $ do
         (getTypeScriptDeclarations (Proxy :: Proxy TwoField)) `shouldBe` [
             TSTypeAlternatives {typeName = "TwoField", typeGenericVariables = [], alternativeTypes = ["ITwoField"]},
             TSInterfaceDeclaration {interfaceName = "ITwoField", interfaceGenericVariables = [], interfaceMembers = [TSField {fieldOptional = False, fieldName = "doubleString", fieldType = "string"}]}
             ]
 
+    it [i|can remove all fields|] $ do
+        (getTypeScriptDeclarations (Proxy :: Proxy EmptyTypeScript)) `shouldBe` [
+            TSTypeAlternatives {typeName = "EmptyTypeScript", typeGenericVariables = [], alternativeTypes = ["IEmptyTypeScript"]},
+            TSInterfaceDeclaration {interfaceName = "IEmptyTypeScript", interfaceGenericVariables = [], interfaceMembers = []}
+            ]
+
+    it [i|ignores aeson field label modifiers|] $ do
+        (getTypeScriptDeclarations (Proxy :: Proxy IgnoreFieldLabelModifier)) `shouldBe` [
+            TSTypeAlternatives {typeName = "IgnoreFieldLabelModifier", typeGenericVariables = [], alternativeTypes = ["IIgnoreFieldLabelModifier"]},
+            TSInterfaceDeclaration {interfaceName = "IIgnoreFieldLabelModifier", interfaceGenericVariables = [], interfaceMembers = [TSField {fieldOptional = False, fieldName = "int", fieldType = "number"}]}
+            ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,6 +16,7 @@ import qualified TwoElemArrayNoTagSingleConstructors
 import qualified TwoElemArrayTagSingleConstructors
 import qualified UntaggedNoTagSingleConstructors
 import qualified UntaggedTagSingleConstructors
+import qualified OmitFields
 import qualified OmitNothingFields
 import qualified NoOmitNothingFields
 import qualified UnwrapUnaryRecords
@@ -36,6 +37,7 @@ main = hspec $ do
   TwoElemArrayNoTagSingleConstructors.tests
   UntaggedTagSingleConstructors.tests
   UntaggedNoTagSingleConstructors.tests
+  OmitFields.allTests
   OmitNothingFields.tests
   NoOmitNothingFields.allTests
   UnwrapUnaryRecords.allTests


### PR DESCRIPTION
This PR adds `omitFields` to `ExtraTypeScriptOptions`. The general ideas was taken from this similar library for generating mobile types from Haskell: https://github.com/MercuryTechnologies/moat

The motivating example is better support for breaking changes to TypeScript types.

When you want to deprecate a record field, to replace it with another field of an incompatible type, typically there's a period of time in which the backend will send both fields simultaneously. This allows existing web clients that have not received the new frontend bundle to continue working, while simultaneously supporting a new frontend bundle that makes use of the new field. Without `omitFields`, the generated TypeScript will include the deprecated field that only exists for older clients. This forces new client code to deal with both fields or humans to edit the generated TypeScript.

Here's a concrete example, imagine you have an existing record:

```haskell
data User { name :: String, age :: Int }
$(deriveJSONAndTypeScript defaultOptions ''User)
```

Let's say you realize what you really want on the client "birthday", not "age". You could do this:

```haskell
data User { name :: String, age :: Int, birthday :: Day }
$(deriveJSONAndTypeScript' defaultOptions ''User defaultExtraTypeScriptOptions {omitFields = ["age"]})
```

You can safely deploy this change immediately, as existing web clients will still be sent the `age` key they expect. You can also cleanly develop a change using `birthday`, since your types no longer contain `age`. It'll be trivial to ensure the entire client has migrated, so removing `age` later (after enough time for existing clients to upgrade) will be very safe.

I've pulled this change into a large production codebase to confirm it works in practice.


There's a potential followup PR to add `omitCases`. The general idea is the same, but it allows for excluding sum type cases, rather than product type fields.